### PR TITLE
Adds deprecation message for gocardless-pro gem

### DIFF
--- a/lib/gocardless-pro.rb
+++ b/lib/gocardless-pro.rb
@@ -5,6 +5,18 @@
 #   https://github.com/gocardless/crank
 #
 
+puts %(
+###########################################################################
+#### WARNING ##############################################################
+# The Ruby Gem `gocardless-pro` is deprecated, in favour of `gocardless_pro`
+# Change your Gemfile to say...
+#
+#   gem 'gocardless_pro'
+#
+# ...to benefit from the latest API features and security updates.
+###########################################################################
+)
+
 require 'json'
 require 'zlib'
 require 'faraday'

--- a/lib/gocardless-pro/version.rb
+++ b/lib/gocardless-pro/version.rb
@@ -4,5 +4,5 @@ end
 
 module GoCardless
   # Current version of the GC gem
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
As discussed, this would never be merged to master. We would cut a new gem and push it to the `gocardless-pro` location.
