### PR TITLE
Allow error handling on idempotency conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,21 @@ These different types of error are fully documented in the [API documentation](h
 - `#request_id`
 - `#errors`
 
-When the API returns an `invalid_state` error due to an `idempotent_creation_conflict`, where possible, the library will automatically retrieve the existing record which was created using the idempotency key.
+When the API returns an `invalid_state` error due to an `idempotent_creation_conflict`,
+this library will attempt to retrieve the existing record which was created using the
+idempotency key, however you can also configure the library to raise an exception instead:
+
+```ruby
+@client = GoCardlessPro::Client.new(
+  on_idempotency_conflict: :raise
+)
+
+begin
+  @client.payments.create(...)
+rescue GoCardlessPro::IdempotencyConflict => e
+  # do something useful
+end
+```
 
 If the client is unable to connect to GoCardless, an appropriate exception will be raised, for example:
 

--- a/lib/gocardless_pro/api_service.rb
+++ b/lib/gocardless_pro/api_service.rb
@@ -11,6 +11,8 @@ require 'base64'
 module GoCardlessPro
   # GoCardless API
   class ApiService
+    attr_reader :on_idempotency_conflict
+
     # Initialize an APIService
     #
     # @param url [String] the URL to make requests to
@@ -31,6 +33,7 @@ module GoCardlessPro
 
       @headers = options[:default_headers] || {}
       @headers['Authorization'] = "Bearer #{token}"
+      @on_idempotency_conflict = options[:on_idempotency_conflict] || :fetch
     end
 
     # Make a request to the API

--- a/lib/gocardless_pro/client.rb
+++ b/lib/gocardless_pro/client.rb
@@ -138,7 +138,7 @@ module GoCardlessPro
           'User-Agent' => user_agent.to_s,
           'Content-Type' => 'application/json',
           'GoCardless-Client-Library' => 'gocardless-pro-ruby',
-          'GoCardless-Client-Version' => '2.12.0',
+          'GoCardless-Client-Version' => '2.13.0',
         },
       }
     end

--- a/lib/gocardless_pro/error/invalid_state_error.rb
+++ b/lib/gocardless_pro/error/invalid_state_error.rb
@@ -19,4 +19,6 @@ module GoCardlessPro
       errors.find { |error| error['reason'] == IDEMPOTENT_CREATION_CONFLICT }
     end
   end
+
+  IdempotencyConflict = Class.new(Error)
 end

--- a/lib/gocardless_pro/services/creditor_bank_accounts_service.rb
+++ b/lib/gocardless_pro/services/creditor_bank_accounts_service.rb
@@ -29,7 +29,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end
@@ -112,7 +121,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end

--- a/lib/gocardless_pro/services/creditors_service.rb
+++ b/lib/gocardless_pro/services/creditors_service.rb
@@ -29,7 +29,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end

--- a/lib/gocardless_pro/services/customer_bank_accounts_service.rb
+++ b/lib/gocardless_pro/services/customer_bank_accounts_service.rb
@@ -41,7 +41,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end
@@ -145,7 +154,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end

--- a/lib/gocardless_pro/services/customers_service.rb
+++ b/lib/gocardless_pro/services/customers_service.rb
@@ -29,7 +29,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end

--- a/lib/gocardless_pro/services/mandate_imports_service.rb
+++ b/lib/gocardless_pro/services/mandate_imports_service.rb
@@ -33,7 +33,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end
@@ -90,7 +99,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end
@@ -126,7 +144,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end

--- a/lib/gocardless_pro/services/mandates_service.rb
+++ b/lib/gocardless_pro/services/mandates_service.rb
@@ -29,7 +29,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end
@@ -131,7 +140,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end
@@ -171,7 +189,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end

--- a/lib/gocardless_pro/services/payments_service.rb
+++ b/lib/gocardless_pro/services/payments_service.rb
@@ -34,7 +34,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end
@@ -136,7 +145,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end
@@ -175,7 +193,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end

--- a/lib/gocardless_pro/services/redirect_flows_service.rb
+++ b/lib/gocardless_pro/services/redirect_flows_service.rb
@@ -30,7 +30,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end
@@ -86,7 +95,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end

--- a/lib/gocardless_pro/services/refunds_service.rb
+++ b/lib/gocardless_pro/services/refunds_service.rb
@@ -40,7 +40,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end

--- a/lib/gocardless_pro/services/subscriptions_service.rb
+++ b/lib/gocardless_pro/services/subscriptions_service.rb
@@ -29,7 +29,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end
@@ -154,7 +163,16 @@ module GoCardlessPro
           # Response doesn't raise any errors until #body is called
           response.tap(&:body)
         rescue InvalidStateError => e
-          return get(e.conflicting_resource_id) if e.idempotent_creation_conflict?
+          if e.idempotent_creation_conflict?
+            case @api_service.on_idempotency_conflict
+            when :raise
+              raise IdempotencyConflict, e.error
+            when :fetch
+              return get(e.conflicting_resource_id)
+            else
+              raise ArgumentError, 'Unknown mode for :on_idempotency_conflict'
+            end
+          end
 
           raise e
         end

--- a/lib/gocardless_pro/version.rb
+++ b/lib/gocardless_pro/version.rb
@@ -4,5 +4,5 @@ end
 
 module GoCardlessPro
   # Current version of the GC gem
-  VERSION = '2.12.0'.freeze
+  VERSION = '2.13.0'.freeze
 end

--- a/spec/services/creditor_bank_accounts_service_spec.rb
+++ b/spec/services/creditor_bank_accounts_service_spec.rb
@@ -186,10 +186,39 @@ describe GoCardlessPro::Services::CreditorBankAccountsService do
           )
       end
 
-      it 'fetches the already-created resource' do
-        post_create_response
-        expect(post_stub).to have_been_requested
-        expect(get_stub).to have_been_requested
+      context 'with default behaviour' do
+        it 'fetches the already-created resource' do
+          post_create_response
+          expect(post_stub).to have_been_requested
+          expect(get_stub).to have_been_requested
+        end
+      end
+
+      context 'with on_idempotency_conflict: :raise' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :raise
+          )
+        end
+
+        it 'raises an IdempotencyConflict error' do
+          expect { post_create_response }.
+            to raise_error(GoCardlessPro::IdempotencyConflict)
+        end
+      end
+
+      context 'with on_idempotency_conflict: :unknown' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :unknown
+          )
+        end
+
+        it 'raises an ArgumentError' do
+          expect { post_create_response }.to raise_error(ArgumentError)
+        end
       end
     end
   end

--- a/spec/services/creditors_service_spec.rb
+++ b/spec/services/creditors_service_spec.rb
@@ -211,10 +211,39 @@ describe GoCardlessPro::Services::CreditorsService do
           )
       end
 
-      it 'fetches the already-created resource' do
-        post_create_response
-        expect(post_stub).to have_been_requested
-        expect(get_stub).to have_been_requested
+      context 'with default behaviour' do
+        it 'fetches the already-created resource' do
+          post_create_response
+          expect(post_stub).to have_been_requested
+          expect(get_stub).to have_been_requested
+        end
+      end
+
+      context 'with on_idempotency_conflict: :raise' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :raise
+          )
+        end
+
+        it 'raises an IdempotencyConflict error' do
+          expect { post_create_response }.
+            to raise_error(GoCardlessPro::IdempotencyConflict)
+        end
+      end
+
+      context 'with on_idempotency_conflict: :unknown' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :unknown
+          )
+        end
+
+        it 'raises an ArgumentError' do
+          expect { post_create_response }.to raise_error(ArgumentError)
+        end
       end
     end
   end

--- a/spec/services/customer_bank_accounts_service_spec.rb
+++ b/spec/services/customer_bank_accounts_service_spec.rb
@@ -186,10 +186,39 @@ describe GoCardlessPro::Services::CustomerBankAccountsService do
           )
       end
 
-      it 'fetches the already-created resource' do
-        post_create_response
-        expect(post_stub).to have_been_requested
-        expect(get_stub).to have_been_requested
+      context 'with default behaviour' do
+        it 'fetches the already-created resource' do
+          post_create_response
+          expect(post_stub).to have_been_requested
+          expect(get_stub).to have_been_requested
+        end
+      end
+
+      context 'with on_idempotency_conflict: :raise' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :raise
+          )
+        end
+
+        it 'raises an IdempotencyConflict error' do
+          expect { post_create_response }.
+            to raise_error(GoCardlessPro::IdempotencyConflict)
+        end
+      end
+
+      context 'with on_idempotency_conflict: :unknown' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :unknown
+          )
+        end
+
+        it 'raises an ArgumentError' do
+          expect { post_create_response }.to raise_error(ArgumentError)
+        end
       end
     end
   end

--- a/spec/services/customers_service_spec.rb
+++ b/spec/services/customers_service_spec.rb
@@ -226,10 +226,39 @@ describe GoCardlessPro::Services::CustomersService do
           )
       end
 
-      it 'fetches the already-created resource' do
-        post_create_response
-        expect(post_stub).to have_been_requested
-        expect(get_stub).to have_been_requested
+      context 'with default behaviour' do
+        it 'fetches the already-created resource' do
+          post_create_response
+          expect(post_stub).to have_been_requested
+          expect(get_stub).to have_been_requested
+        end
+      end
+
+      context 'with on_idempotency_conflict: :raise' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :raise
+          )
+        end
+
+        it 'raises an IdempotencyConflict error' do
+          expect { post_create_response }.
+            to raise_error(GoCardlessPro::IdempotencyConflict)
+        end
+      end
+
+      context 'with on_idempotency_conflict: :unknown' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :unknown
+          )
+        end
+
+        it 'raises an ArgumentError' do
+          expect { post_create_response }.to raise_error(ArgumentError)
+        end
       end
     end
   end

--- a/spec/services/mandate_imports_service_spec.rb
+++ b/spec/services/mandate_imports_service_spec.rb
@@ -156,10 +156,39 @@ describe GoCardlessPro::Services::MandateImportsService do
           )
       end
 
-      it 'fetches the already-created resource' do
-        post_create_response
-        expect(post_stub).to have_been_requested
-        expect(get_stub).to have_been_requested
+      context 'with default behaviour' do
+        it 'fetches the already-created resource' do
+          post_create_response
+          expect(post_stub).to have_been_requested
+          expect(get_stub).to have_been_requested
+        end
+      end
+
+      context 'with on_idempotency_conflict: :raise' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :raise
+          )
+        end
+
+        it 'raises an IdempotencyConflict error' do
+          expect { post_create_response }.
+            to raise_error(GoCardlessPro::IdempotencyConflict)
+        end
+      end
+
+      context 'with on_idempotency_conflict: :unknown' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :unknown
+          )
+        end
+
+        it 'raises an ArgumentError' do
+          expect { post_create_response }.to raise_error(ArgumentError)
+        end
       end
     end
   end

--- a/spec/services/mandates_service_spec.rb
+++ b/spec/services/mandates_service_spec.rb
@@ -181,10 +181,39 @@ describe GoCardlessPro::Services::MandatesService do
           )
       end
 
-      it 'fetches the already-created resource' do
-        post_create_response
-        expect(post_stub).to have_been_requested
-        expect(get_stub).to have_been_requested
+      context 'with default behaviour' do
+        it 'fetches the already-created resource' do
+          post_create_response
+          expect(post_stub).to have_been_requested
+          expect(get_stub).to have_been_requested
+        end
+      end
+
+      context 'with on_idempotency_conflict: :raise' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :raise
+          )
+        end
+
+        it 'raises an IdempotencyConflict error' do
+          expect { post_create_response }.
+            to raise_error(GoCardlessPro::IdempotencyConflict)
+        end
+      end
+
+      context 'with on_idempotency_conflict: :unknown' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :unknown
+          )
+        end
+
+        it 'raises an ArgumentError' do
+          expect { post_create_response }.to raise_error(ArgumentError)
+        end
       end
     end
   end

--- a/spec/services/payments_service_spec.rb
+++ b/spec/services/payments_service_spec.rb
@@ -191,10 +191,39 @@ describe GoCardlessPro::Services::PaymentsService do
           )
       end
 
-      it 'fetches the already-created resource' do
-        post_create_response
-        expect(post_stub).to have_been_requested
-        expect(get_stub).to have_been_requested
+      context 'with default behaviour' do
+        it 'fetches the already-created resource' do
+          post_create_response
+          expect(post_stub).to have_been_requested
+          expect(get_stub).to have_been_requested
+        end
+      end
+
+      context 'with on_idempotency_conflict: :raise' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :raise
+          )
+        end
+
+        it 'raises an IdempotencyConflict error' do
+          expect { post_create_response }.
+            to raise_error(GoCardlessPro::IdempotencyConflict)
+        end
+      end
+
+      context 'with on_idempotency_conflict: :unknown' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :unknown
+          )
+        end
+
+        it 'raises an ArgumentError' do
+          expect { post_create_response }.to raise_error(ArgumentError)
+        end
       end
     end
   end

--- a/spec/services/redirect_flows_service_spec.rb
+++ b/spec/services/redirect_flows_service_spec.rb
@@ -181,10 +181,39 @@ describe GoCardlessPro::Services::RedirectFlowsService do
           )
       end
 
-      it 'fetches the already-created resource' do
-        post_create_response
-        expect(post_stub).to have_been_requested
-        expect(get_stub).to have_been_requested
+      context 'with default behaviour' do
+        it 'fetches the already-created resource' do
+          post_create_response
+          expect(post_stub).to have_been_requested
+          expect(get_stub).to have_been_requested
+        end
+      end
+
+      context 'with on_idempotency_conflict: :raise' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :raise
+          )
+        end
+
+        it 'raises an IdempotencyConflict error' do
+          expect { post_create_response }.
+            to raise_error(GoCardlessPro::IdempotencyConflict)
+        end
+      end
+
+      context 'with on_idempotency_conflict: :unknown' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :unknown
+          )
+        end
+
+        it 'raises an ArgumentError' do
+          expect { post_create_response }.to raise_error(ArgumentError)
+        end
       end
     end
   end

--- a/spec/services/refunds_service_spec.rb
+++ b/spec/services/refunds_service_spec.rb
@@ -171,10 +171,39 @@ describe GoCardlessPro::Services::RefundsService do
           )
       end
 
-      it 'fetches the already-created resource' do
-        post_create_response
-        expect(post_stub).to have_been_requested
-        expect(get_stub).to have_been_requested
+      context 'with default behaviour' do
+        it 'fetches the already-created resource' do
+          post_create_response
+          expect(post_stub).to have_been_requested
+          expect(get_stub).to have_been_requested
+        end
+      end
+
+      context 'with on_idempotency_conflict: :raise' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :raise
+          )
+        end
+
+        it 'raises an IdempotencyConflict error' do
+          expect { post_create_response }.
+            to raise_error(GoCardlessPro::IdempotencyConflict)
+        end
+      end
+
+      context 'with on_idempotency_conflict: :unknown' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :unknown
+          )
+        end
+
+        it 'raises an ArgumentError' do
+          expect { post_create_response }.to raise_error(ArgumentError)
+        end
       end
     end
   end

--- a/spec/services/subscriptions_service_spec.rb
+++ b/spec/services/subscriptions_service_spec.rb
@@ -221,10 +221,39 @@ describe GoCardlessPro::Services::SubscriptionsService do
           )
       end
 
-      it 'fetches the already-created resource' do
-        post_create_response
-        expect(post_stub).to have_been_requested
-        expect(get_stub).to have_been_requested
+      context 'with default behaviour' do
+        it 'fetches the already-created resource' do
+          post_create_response
+          expect(post_stub).to have_been_requested
+          expect(get_stub).to have_been_requested
+        end
+      end
+
+      context 'with on_idempotency_conflict: :raise' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :raise
+          )
+        end
+
+        it 'raises an IdempotencyConflict error' do
+          expect { post_create_response }.
+            to raise_error(GoCardlessPro::IdempotencyConflict)
+        end
+      end
+
+      context 'with on_idempotency_conflict: :unknown' do
+        let(:client) do
+          GoCardlessPro::Client.new(
+            access_token: 'SECRET_TOKEN',
+            on_idempotency_conflict: :unknown
+          )
+        end
+
+        it 'raises an ArgumentError' do
+          expect { post_create_response }.to raise_error(ArgumentError)
+        end
       end
     end
   end


### PR DESCRIPTION
Integrators cannot currently handle idempotency conflicts, because our library swallows the exception and simply refetches the resource.

This is normally a reasonable behaviour, however this means that you also can't detect the failure and do something useful.

This commit allows configuration for the client, to explicitly re-raise an exception to be handled appropriately.

Fixes https://github.com/gocardless/gocardless-pro-ruby/issues/39