### PR TITLE
Bump version numbers in client code to 2.16.0

### DIFF
--- a/lib/gocardless_pro/client.rb
+++ b/lib/gocardless_pro/client.rb
@@ -143,7 +143,7 @@ module GoCardlessPro
           'User-Agent' => user_agent.to_s,
           'Content-Type' => 'application/json',
           'GoCardless-Client-Library' => 'gocardless-pro-ruby',
-          'GoCardless-Client-Version' => '2.15.1',
+          'GoCardless-Client-Version' => '2.16.0',
         },
       }
     end

--- a/lib/gocardless_pro/version.rb
+++ b/lib/gocardless_pro/version.rb
@@ -4,5 +4,5 @@ end
 
 module GoCardlessPro
   # Current version of the GC gem
-  VERSION = '2.15.1'.freeze
+  VERSION = '2.16.0'.freeze
 end


### PR DESCRIPTION
Not sure why this didn't get pushed from the template build, but alas, it is necessary to publish the gem.