### PR TITLE
[MIXP-1488] Add CircleCI workflow to publish on RubyGems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,20 @@ jobs:
     steps:
       - checkout
       - run: bundle install && bundle exec rspec
-
+  publish: &publish
+    docker:
+      - image: ruby:2.6
+    steps:
+      - checkout
+      - run: |
+          echo ${RUBYGEM_PUBLISH_API_KEY}
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: $RUBYGEM_PUBLISH_API_KEY\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          cat $HOME/.gem/credentials
+          gem push *.gem
 workflows:
   version: 2
   tests:
@@ -30,3 +43,6 @@ workflows:
                 ruby-version: "2.2"
               - faraday-version: "0.9.2"
                 ruby-version: "3.0"
+      - publish:
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,13 +19,11 @@ jobs:
     steps:
       - checkout
       - run: |
-          echo ${RUBYGEM_PUBLISH_API_KEY}
           mkdir -p $HOME/.gem
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
           printf -- "---\n:rubygems_api_key: $RUBYGEM_PUBLISH_API_KEY\n" > $HOME/.gem/credentials
           gem build *.gemspec
-          cat $HOME/.gem/credentials
           gem push *.gem
           
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
           gem build *.gemspec
           cat $HOME/.gem/credentials
           gem push *.gem
+          
 workflows:
   version: 2
   tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,5 +45,9 @@ workflows:
               - faraday-version: "0.9.2"
                 ruby-version: "3.0"
       - publish:
+          filters:
+            branches:
+              only:
+                - master      
           requires:
             - test


### PR DESCRIPTION
Ref: https://gocardless.atlassian.net/browse/MIXP-1488

This PR adds CircleCI workflow which automates publishing gocardless-pro gem on RubyGem store when there are changes detected on master.