### PR TITLE
Release 2.38.0

### DIFF
--- a/lib/gocardless_pro/client.rb
+++ b/lib/gocardless_pro/client.rb
@@ -198,7 +198,7 @@ module GoCardlessPro
           'User-Agent' => user_agent.to_s,
           'Content-Type' => 'application/json',
           'GoCardless-Client-Library' => 'gocardless-pro-ruby',
-          'GoCardless-Client-Version' => '2.37.0',
+          'GoCardless-Client-Version' => '2.38.0',
         },
       }
     end

--- a/lib/gocardless_pro/services/blocks_service.rb
+++ b/lib/gocardless_pro/services/blocks_service.rb
@@ -169,10 +169,10 @@ module GoCardlessPro
       # Returns 201 if at least one block was created. Returns 200 if there were no
       # new
       # blocks created.
-      # Example URL: /block_by_ref
+      # Example URL: /blocks/block_by_ref
       # @param options [Hash] parameters as a hash, under a params key.
       def block_by_ref(options = {})
-        path = '/block_by_ref'
+        path = '/blocks/block_by_ref'
 
         params = options.delete(:params) || {}
         options[:params] = {}

--- a/lib/gocardless_pro/version.rb
+++ b/lib/gocardless_pro/version.rb
@@ -4,5 +4,5 @@ end
 
 module GoCardlessPro
   # Current version of the GC gem
-  VERSION = '2.37.0'.freeze
+  VERSION = '2.38.0'.freeze
 end

--- a/spec/resources/block_spec.rb
+++ b/spec/resources/block_spec.rb
@@ -504,8 +504,8 @@ describe GoCardlessPro::Resources::Block do
     let(:resource_id) { 'ABC123' }
 
     let!(:stub) do
-      # /block_by_ref
-      stub_url = '/block_by_ref'.gsub(':identity', resource_id)
+      # /blocks/block_by_ref
+      stub_url = '/blocks/block_by_ref'.gsub(':identity', resource_id)
       stub_request(:post, /.*api.gocardless.com#{stub_url}/).to_return(
 
         body: {
@@ -549,8 +549,8 @@ describe GoCardlessPro::Resources::Block do
       let(:resource_id) { 'ABC123' }
 
       let!(:stub) do
-        # /block_by_ref
-        stub_url = '/block_by_ref'.gsub(':identity', resource_id)
+        # /blocks/block_by_ref
+        stub_url = '/blocks/block_by_ref'.gsub(':identity', resource_id)
         stub_request(:post, /.*api.gocardless.com#{stub_url}/).
           with(
             body: { foo: 'bar' },

--- a/spec/services/blocks_service_spec.rb
+++ b/spec/services/blocks_service_spec.rb
@@ -756,8 +756,8 @@ describe GoCardlessPro::Services::BlocksService do
     let(:resource_id) { 'ABC123' }
 
     let!(:stub) do
-      # /block_by_ref
-      stub_url = '/block_by_ref'.gsub(':identity', resource_id)
+      # /blocks/block_by_ref
+      stub_url = '/blocks/block_by_ref'.gsub(':identity', resource_id)
       stub_request(:post, /.*api.gocardless.com#{stub_url}/).to_return(
 
         body: {
@@ -797,7 +797,7 @@ describe GoCardlessPro::Services::BlocksService do
 
     describe 'retry behaviour' do
       it "doesn't retry errors" do
-        stub_url = '/block_by_ref'.gsub(':identity', resource_id)
+        stub_url = '/blocks/block_by_ref'.gsub(':identity', resource_id)
         stub = stub_request(:post, /.*api.gocardless.com#{stub_url}/).
                to_timeout
 
@@ -812,8 +812,8 @@ describe GoCardlessPro::Services::BlocksService do
       let(:resource_id) { 'ABC123' }
 
       let!(:stub) do
-        # /block_by_ref
-        stub_url = '/block_by_ref'.gsub(':identity', resource_id)
+        # /blocks/block_by_ref
+        stub_url = '/blocks/block_by_ref'.gsub(':identity', resource_id)
         stub_request(:post, /.*api.gocardless.com#{stub_url}/).
           with(
             body: { foo: 'bar' },


### PR DESCRIPTION
Updates include:
- Making `creditor_type` and `country_code` required when creating creditors via the API (for payment providers);
- Removing `null` as an allowed value for `creditor_type` when creating creditors.