### PR TITLE
Update supported ruby versions to 3.2, 3.3 and 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
         faraday-version:
           - '2.0'
         ruby-version:
-          - '2.6'
-          - '2.7'
-          - '3.1'
           - '3.2'
+          - '3.3'
+          - '3.4'
     env:
       FARADAY_VERSION: ${{ matrix.faraday-version }}
     steps:

--- a/gocardless_pro.gemspec
+++ b/gocardless_pro.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6'
   spec.add_dependency 'faraday', ['>= 2', '< 3']
+  spec.add_dependency 'base64'
 
   spec.add_development_dependency 'rspec', '~> 3.7.0'
   spec.add_development_dependency 'webmock', '~> 3.8.3'


### PR DESCRIPTION
The old versions have been unsupported since at least 2021 https://www.ruby-lang.org/en/downloads/branches/