### PR TITLE
Update supported ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       FARADAY_VERSION: ${{ matrix.faraday-version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
@@ -36,7 +36,7 @@ jobs:
     needs:
       - test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '4.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         faraday-version:
           - '2.0'
         ruby-version:
-          - '3.2'
           - '3.3'
           - '3.4'
+          - '4.0'
     env:
       FARADAY_VERSION: ${{ matrix.faraday-version }}
     steps:
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '4.0'
           bundler-cache: true
       - run: |
           mkdir -p $HOME/.gem


### PR DESCRIPTION
To keep in sync with: https://github.com/gocardless/client-library-templates/pull/31

https://endoflife.date/ruby