### PR TITLE
Improve releasing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,12 @@ jobs:
           printf -- "---\n:rubygems_api_key: $RUBYGEM_PUBLISH_API_KEY\n" > $HOME/.gem/credentials
           gem build *.gemspec
           gem push *.gem
+      - name: Create GitHub Release
+        if: steps.version_check.outputs.already_published == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=${{ steps.version_check.outputs.version }}
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --generate-notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,21 @@ jobs:
         with:
           ruby-version: '4.0'
           bundler-cache: true
-      - run: |
+      - name: Check if version is already released
+        id: version_check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(ruby -r ./lib/gocardless_pro/version.rb -e 'puts GoCardlessPro::VERSION')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            echo "already_published=true" >> $GITHUB_OUTPUT
+          else
+            echo "already_published=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Build and publish gem
+        if: steps.version_check.outputs.already_published == 'false'
+        run: |
           mkdir -p $HOME/.gem
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials


### PR DESCRIPTION
This adds two things we do on our other client libraries:

1. Automatically create releases - not doing this caused https://github.com/gocardless/gocardless-pro-ruby/issues/154
2. Only attempt to publish a version if it hasn't been published - otherwise the build errors if we merge to master without a version bump