### PR TITLE
Add all-tests-passed aggregator job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,19 @@ jobs:
           bundler-cache: true
       - run: bundle install && bundle exec rspec
 
+  all-tests-passed:
+    name: All tests passed
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: always()
+    steps:
+      - name: Check test job status
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "test job did not succeed"
+            exit 1
+          fi
+
   publish:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds an `all-tests-passed` job that depends on the whole `test` matrix (faraday x ruby versions) and fails if any entry didn't succeed.

## Why
Part of IX-2323: setting up required status checks across GoCardless's public client library repos so we can safely enable auto-merge. The `test` matrix produces one check per faraday/ruby combination, which is brittle to require individually in branch protection since the list shifts whenever a version is added or dropped. `all-tests-passed` gives branch protection a single stable check name to require instead.

## Test plan
- [x] Confirm `all-tests-passed` appears and passes on this PR