### PR TITLE
Explicitly set release title so it matches the tag name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           NOTES="${{ steps.notes.outputs.notes }}"
+          TAG="v${{ steps.version_check.outputs.version }}"
           if [ -n "$(echo "$NOTES" | tr -d '[:space:]')" ]; then
-            gh release create v${{ steps.version_check.outputs.version }} --notes "$NOTES"
+            gh release create "$TAG" --title "$TAG" --notes "$NOTES"
           else
-            gh release create v${{ steps.version_check.outputs.version }} --generate-notes
+            gh release create "$TAG" --title "$TAG" --generate-notes
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!-- This file is generated, please add to it using `knope document-change` in the client-library-templates repo -->
 # Changelog
 
+## 4.5.0 (2026-08-11)
+
+### Features
+
+- Add roles attribute to the Institution resource
+
 ## 4.4.1
 
 Start of changelog tracking with Knope. See [GitHub releases](https://github.com/gocardless/gocardless-pro-ruby/releases) for the history of earlier versions.

--- a/lib/gocardless_pro/client.rb
+++ b/lib/gocardless_pro/client.rb
@@ -283,7 +283,7 @@ module GoCardlessPro
           'User-Agent' => "#{user_agent}",
           'Content-Type' => 'application/json',
           'GoCardless-Client-Library' => 'gocardless-pro-ruby',
-          'GoCardless-Client-Version' => '4.4.1',
+          'GoCardless-Client-Version' => '4.5.0',
         },
       }
     end

--- a/lib/gocardless_pro/version.rb
+++ b/lib/gocardless_pro/version.rb
@@ -3,5 +3,5 @@ end
 
 module GoCardlessPro
   # Current version of the GC gem
-  VERSION = '4.4.1'
+  VERSION = '4.5.0'
 end


### PR DESCRIPTION
## Summary
* `gh release create` was leaving the release title blank when notes come from the changelog (`--notes`), so GitHub fell back to showing the merge commit message as the title instead of e.g. "v1.2.3".
* Both branches of the release-creation step now pass `--title` explicitly so it always matches the tag name.

This mirrors the same fix applied in gocardless-nodejs (gocardless/gocardless-nodejs#256).

## Test plan
- [ ] Confirm the next automated release gets the correct title