### PR TITLE
Improve scope of publish token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - master
 
-env:
-  RUBYGEM_PUBLISH_API_KEY: ${{ secrets.RUBYGEM_PUBLISH_API_KEY }}
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -68,6 +65,8 @@ jobs:
           fi
       - name: Build and publish gem
         if: steps.version_check.outputs.already_published == 'false'
+        env:
+          RUBYGEM_PUBLISH_API_KEY: ${{ secrets.RUBYGEM_PUBLISH_API_KEY }}
         run: |
           mkdir -p $HOME/.gem
           touch $HOME/.gem/credentials


### PR DESCRIPTION
Improve scope of publish token - to prevent supply chain attacks. 