### PR TITLE
Fix release notes shell injection in create_release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,8 @@ jobs:
         if: steps.version_check.outputs.already_published == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
+          NOTES: ${{ steps.notes.outputs.notes }}
         run: |
-          NOTES="${{ steps.notes.outputs.notes }}"
           TAG="v${{ steps.version_check.outputs.version }}"
           if [ -n "$(echo "$NOTES" | tr -d '[:space:]')" ]; then
             gh release create "$TAG" --title "$TAG" --notes "$NOTES"


### PR DESCRIPTION
## Summary
- Changelog entries containing backticks (e.g. `` `resource_type: x` ``) were interpolated directly into a double-quoted bash string in the release step, causing bash to treat the backticks as command substitution instead of literal text.
- Fixes this by passing the notes via the step's `env:` context instead, so the value is expanded as a shell variable rather than re-parsed as script text.

Same fix as [gocardless/gocardless-pro-python#146](https://github.com/gocardless/gocardless-pro-python/pull/146), which hit this in production when a v3.7.0 changelog entry contained backticked code.

## Test plan
- [x] Reproduced the original failure locally with the affected changelog text and confirmed the old pattern fails identically
- [x] Confirmed the new pattern preserves the notes text literally with no shell execution
